### PR TITLE
 Fixes for 0.7. Currently doesn't work yet because of FileIO.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 deps/Atlas
+deps/build.log
+

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 RigidBodyDynamics 0.4.0
+StaticArrays

--- a/src/AtlasRobot.jl
+++ b/src/AtlasRobot.jl
@@ -6,7 +6,7 @@ using RigidBodyDynamics
 using RigidBodyDynamics.Contact
 using StaticArrays
 
-packagepath() = joinpath(dirname(@__DIR__), "deps")
+packagepath() = joinpath(@__DIR__, "..", "deps")
 urdfpath() = joinpath(packagepath(), "Atlas", "atlas.urdf")
 
 function default_contact_model()

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-RigidBodyTreeInspector 0.1.1
+MechanismGeometries 0.0.3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using AtlasRobot
-using RigidBodyTreeInspector
-using Base.Test
+using MechanismGeometries
+using Compat.Test
 
 @testset "load geometries" begin
     mechanism = AtlasRobot.mechanism()
-    geometries = RigidBodyTreeInspector.parse_urdf(AtlasRobot.urdfpath(), mechanism; package_path = [AtlasRobot.packagepath()]);
-    @test length(geometries) == 48
+    visuals = URDFVisuals(AtlasRobot.urdfpath(); package_path = [AtlasRobot.packagepath()])
+    meshgeometry = visual_elements(mechanism, visuals)
+    @test length(meshgeometry) == 48
 end


### PR DESCRIPTION
Also lose RigidBodyTreeInspector as a test dependency (use MechanismGeometries instead).